### PR TITLE
Update to 470 driver release

### DIFF
--- a/genmodules.py
+++ b/genmodules.py
@@ -53,6 +53,11 @@ BRANCH_PKGS = [
   'cuda-drivers',
 ]
 
+# Add-ons
+OPTIONAL_PKGS = [
+  'nvidia-fabric-manager',
+]
+
 class Writer:
     output = ''
 
@@ -321,6 +326,7 @@ if __name__ == '__main__':
         out.tab().line('artifacts:')
         out.tab().tab().line('rpms:')
         existing_branch_pkgs = set()
+        optional_branch_pkgs = set()
 
         for pkg in BRANCH_PKGS:
             latest_pkg = latest_rpm_from_pkgname(rpm_files, pkg, branch.version())
@@ -332,6 +338,11 @@ if __name__ == '__main__':
             for p in all_rpms_from_pkgname(rpm_files, pkg, branch.major):
                 out.tab().tab().tab().line('- ' + filename_to_nevra(p, repodir))
                 existing_branch_pkgs.add(pkg)
+
+        for opt in OPTIONAL_PKGS:
+            for o in all_rpms_from_pkgname(rpm_files, opt, branch.major):
+                out.tab().tab().tab().line('- ' + filename_to_nevra(o, repodir))
+                optional_branch_pkgs.add(opt)
 
         for pkg in LATEST_PKGS:
             latest_pkg = latest_rpm_from_pkgname(rpm_files, pkg)
@@ -379,10 +390,10 @@ if __name__ == '__main__':
             if branch.is_dkms():
                 out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
             if "latest" in branch.name:
-                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + latest.major)
+                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
                 out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
             else:
-                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
+                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
                 out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
 
         out.tab().tab().line('ks:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -361,8 +361,14 @@ if __name__ == '__main__':
         out.tab().tab().tab().line('rpms:')
         for pkg in sorted(existing_branch_pkgs):
             out.tab().tab().tab().tab().line('- ' + pkg)
+
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+        else:
+            out.tab().tab().line('src:')
+            out.tab().tab().tab().line('description: Source headers for compilation')
+            out.tab().tab().tab().line('rpms:')
+            out.tab().tab().tab().tab().line('- nvidia-kmod-headers')
 
         if branch.arch == "x86_64":
             out.tab().tab().line('fm:')
@@ -385,6 +391,7 @@ if __name__ == '__main__':
         for pkg in sorted(existing_branch_pkgs):
             if "cuda-drivers" not in pkg:
                 out.tab().tab().tab().tab().line('- ' + pkg)
+
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 

--- a/genmodules.py
+++ b/genmodules.py
@@ -288,10 +288,10 @@ if __name__ == '__main__':
             dkms_pkg = rpm_from_pkgname(rpm_files, 'kmod-nvidia-latest-dkms', branch.version())
             if dkms_pkg:
                 out.tab().tab().tab().line('- ' + filename_to_nevra(dkms_pkg, repodir))
-
-        # All the kmod rpms which belong to this branch
-        for rpm in filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms):
-            out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
+        else:
+            # All the kmod rpms which belong to this branch
+            for rpm in filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms):
+                out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
 
         out.tab().line('profiles:')
         out.tab().tab().line('default:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -347,6 +347,20 @@ if __name__ == '__main__':
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
+        out.tab().tab().line('fm:')
+        out.tab().tab().tab().line('description: FabricManager installation')
+        out.tab().tab().tab().line('rpms:')
+        for pkg in sorted(existing_branch_pkgs):
+            out.tab().tab().tab().tab().line('- ' + pkg)
+        if branch.is_dkms():
+            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+        if "latest" in branch.name:
+            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + latest.major)
+            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
+        else:
+            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
+            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
+
         out.tab().tab().line('ks:')
         out.tab().tab().tab().line('description: Installation via kickstart')
         out.tab().tab().tab().line('rpms:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -75,7 +75,7 @@ class Writer:
 
 
 class Branch:
-    def __init__(self, name, major, minor, micro = None, arch = 'x86_64'):
+    def __init__(self, name, major, minor, micro = None, arch = "noarch"):
         self.name = name
         self.major = major
         self.minor = minor
@@ -347,19 +347,20 @@ if __name__ == '__main__':
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
-        out.tab().tab().line('fm:')
-        out.tab().tab().tab().line('description: FabricManager installation')
-        out.tab().tab().tab().line('rpms:')
-        for pkg in sorted(existing_branch_pkgs):
-            out.tab().tab().tab().tab().line('- ' + pkg)
-        if branch.is_dkms():
-            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
-        if "latest" in branch.name:
-            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + latest.major)
-            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
-        else:
-            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
-            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
+        if branch.arch == "x86_64":
+            out.tab().tab().line('fm:')
+            out.tab().tab().tab().line('description: FabricManager installation')
+            out.tab().tab().tab().line('rpms:')
+            for pkg in sorted(existing_branch_pkgs):
+                out.tab().tab().tab().tab().line('- ' + pkg)
+            if branch.is_dkms():
+                out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+            if "latest" in branch.name:
+                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + latest.major)
+                out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
+            else:
+                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
+                out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
 
         out.tab().tab().line('ks:')
         out.tab().tab().tab().line('description: Installation via kickstart')

--- a/genmodules.py
+++ b/genmodules.py
@@ -129,7 +129,7 @@ def kmod_belongs_to(kmod_filename, branch):
     return branch.version() in kmod_filename
 
 def get_rpm_epoch(rpmfile, repodir):
-    cmd = ['rpm', '-q', '--qf', '%{epochnum}', repodir + rpmfile]
+    cmd = ['rpm', '-qp', '--nosignature', '--qf', '%{epochnum}', repodir + rpmfile]
     null = open(os.devnull, 'w')
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=null)
     stdout = process.communicate()[0]

--- a/genmodules.py
+++ b/genmodules.py
@@ -228,6 +228,17 @@ if __name__ == '__main__':
 
     branches = sorted(branches)
 
+    if len(branches) == 0:
+        print('Error: Could not determine branches from the given rpm files in ' + repodir)
+        print('RPM files found:')
+        for p in repodir_contents:
+            print(' - ' + str(p))
+        print('Driver rpms:')
+        for p in driver_rpms:
+            print(' - ' + str(p))
+
+        sys.exit()
+
     # Add 'latest' branch with the same version as the highest-versioned other branch
     latest = branches[0]
     latest_branch = Branch('latest', latest.major, latest.minor)

--- a/genmodules.py
+++ b/genmodules.py
@@ -399,6 +399,16 @@ if __name__ == '__main__':
                 out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
                 out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
 
+        if branch.arch == "aarch64" and int(branch.major) > 470:
+            out.tab().tab().line('fm:')
+            out.tab().tab().tab().line('description: FabricManager installation')
+            out.tab().tab().tab().line('rpms:')
+            for pkg in sorted(existing_branch_pkgs):
+                out.tab().tab().tab().tab().line('- ' + pkg)
+            if branch.is_dkms():
+                out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
+
         out.tab().tab().line('ks:')
         out.tab().tab().tab().line('description: Installation via kickstart')
         out.tab().tab().tab().line('rpms:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -308,7 +308,7 @@ if __name__ == '__main__':
     out.line('version: 1')
     out.line('data:')
     out.tab().line('module: nvidia-driver')
-    out.tab().line('stream: latest')
+    out.tab().line('stream: latest-dkms')
     out.tab().line('profiles:')
     for branch in branches:
         out.tab().tab().line(branch.name + ': [default]')

--- a/genmodules.py
+++ b/genmodules.py
@@ -329,8 +329,12 @@ if __name__ == '__main__':
                 print('WARNING: RPM kmod-nvidia-latest-dkms in version ' + branch.version() + ' not found')
         else:
             # All the kmod rpms which belong to this branch
-            for rpm in filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms):
-                out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
+            kmod_rpms = list(filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms))
+            if not kmod_rpms:
+                print('WARNING: Branch %s in version %s is not a DKMS branch, but no precompiled kmod packages can be found' % (branch.name, branch.version()))
+            else:
+                for rpm in kmod_rpms:
+                    out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
 
         out.tab().line('profiles:')
         out.tab().tab().line('default:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -392,6 +392,9 @@ if __name__ == '__main__':
             if "latest" in branch.name:
                 out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
                 out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
+            elif int(branch.major) < 460:
+                out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
+                out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
             else:
                 out.tab().tab().tab().tab().line('- ' + 'nvidia-fabric-manager')
                 out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)

--- a/genmodules.py
+++ b/genmodules.py
@@ -1,4 +1,4 @@
-#!/bin/env python2
+#!/bin/env python3
 
 from __future__ import print_function
 from os import listdir
@@ -303,6 +303,8 @@ if __name__ == '__main__':
             dkms_pkg = latest_rpm_from_pkgname(rpm_files, 'kmod-nvidia-latest-dkms', branch.version())
             if dkms_pkg:
                 out.tab().tab().tab().line('- ' + filename_to_nevra(dkms_pkg, repodir))
+            else:
+                print('WARNING: RPM kmod-nvidia-latest-dkms in version ' + branch.version() + ' not found')
         else:
             # All the kmod rpms which belong to this branch
             for rpm in filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms):

--- a/genmodules.py
+++ b/genmodules.py
@@ -330,11 +330,11 @@ if __name__ == '__main__':
                 print('WARNING: RPM kmod-nvidia-latest-dkms in version ' + branch.version() + ' not found')
         else:
             # All the kmod rpms which belong to this branch
-            kmod_rpms = list(filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms))
-            if not kmod_rpms:
+            branch_kmod_rpms = list(filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms))
+            if not branch_kmod_rpms:
                 print('WARNING: Branch %s in version %s is not a DKMS branch, but no precompiled kmod packages can be found' % (branch.name, branch.version()))
             else:
-                for rpm in kmod_rpms:
+                for rpm in branch_kmod_rpms:
                     out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
 
         out.tab().line('profiles:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -106,7 +106,7 @@ class Branch:
 
 def get_stream_hash(name, stream, version, distro):
     uniq_str = name + stream + version + distro
-    hash_str = hashlib.md5(uniq_str.encode('utf-8')).hexdigest()[:12]
+    hash_str = hashlib.md5(uniq_str.encode('utf-8')).hexdigest()[:10]
     print('context: ' + hash_str + ' = ', name, stream, version, distro)
 
     return hash_str

--- a/genmodules.py
+++ b/genmodules.py
@@ -347,6 +347,15 @@ if __name__ == '__main__':
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
+        out.tab().tab().line('ks:')
+        out.tab().tab().tab().line('description: Installation via kickstart')
+        out.tab().tab().tab().line('rpms:')
+        for pkg in sorted(existing_branch_pkgs):
+            if "cuda-drivers" not in pkg:
+                out.tab().tab().tab().tab().line('- ' + pkg)
+        if branch.is_dkms():
+            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+
         out.next()
 
     out.line('document: modulemd-defaults')

--- a/genmodules.py
+++ b/genmodules.py
@@ -260,6 +260,7 @@ if __name__ == '__main__':
         if n_branches == 0 or (n_branches > 0 and branches[n_branches - 1].major != major):
             arch = arch_from_rpm_filename(pkg)
             branches.append(Branch(major, major, minor, micro, arch))
+            branches.append(Branch(major + "-dkms", major, minor, micro, arch))
 
     branches = sorted(branches)
 
@@ -340,7 +341,7 @@ if __name__ == '__main__':
         out.tab().tab().line('default:')
         out.tab().tab().tab().line('description: Default installation')
         out.tab().tab().tab().line('rpms:')
-        for pkg in existing_branch_pkgs:
+        for pkg in sorted(existing_branch_pkgs):
             out.tab().tab().tab().tab().line('- ' + pkg)
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')

--- a/genmodules.py
+++ b/genmodules.py
@@ -47,7 +47,7 @@ BRANCH_PKGS = [
   'nvidia-xconfig',
   'nvidia-kmod-common',
 
-  'cuda-drivers-redhat',
+  'cuda-drivers',
 ]
 
 class Writer:
@@ -122,7 +122,7 @@ def kmod_belongs_to(kmod_filename, branch):
 
 def get_rpm_epoch(rpmfile, repodir):
     cmd = ['rpm', '-q', '--qf', '%{epochnum}', repodir + rpmfile]
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=None)
     stdout = process.communicate()[0]
 
     return stdout.decode('utf-8')
@@ -270,7 +270,7 @@ if __name__ == '__main__':
         out.tab().tab().tab().line('rpms:')
         out.tab().tab().tab().tab().line('- ' + BRANCH_PKGS[0])
         if branch.is_dkms():
-            out.tab().tab().tab().tab().line('- dkms-nvidia')
+            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
 
         out.tab().line('artifacts:')
@@ -289,7 +289,7 @@ if __name__ == '__main__':
             out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
 
         if branch.is_dkms():
-            dkms_pkg = rpm_from_pkgname(rpm_files, 'dkms-nvidia', branch.version())
+            dkms_pkg = rpm_from_pkgname(rpm_files, 'kmod-nvidia-latest-dkms', branch.version())
             if dkms_pkg:
                 out.tab().tab().tab().line('- ' + filename_to_nevra(dkms_pkg, repodir))
 

--- a/genmodules.py
+++ b/genmodules.py
@@ -1,0 +1,285 @@
+#!/bin/env python
+
+from __future__ import print_function
+from os import listdir
+from os.path import isfile, join
+import datetime
+import os.path
+import sys
+import glob
+import subprocess
+
+# https://github.com/fedora-modularity/libmodulemd/blob/master/spec.v2.yaml
+
+# We need a module.yaml file that we pass to modifyrepo so dnf knows
+# how the stream are made up.
+#
+# Here we generate the module.yaml file.
+KMOD_PKG_PREFIX = 'kmod-nvidia'
+
+DESCRIPTION = [
+  'This package provides the most recent NVIDIA display driver which allows for',
+  'hardware accelerated rendering with recent NVIDIA chipsets.',
+  '',
+  'For the full product support list, please consult the release notes for',
+  'driver version {version}.',
+]
+
+# Unrelated to the version a branch is at, we always
+# use the latest version of these rpms in every branch
+LATEST_PKGS = [
+  'dnf-plugin-nvidia',
+]
+
+# Main package must be first!
+BRANCH_PKGS = [
+  'nvidia-driver',
+  'nvidia-driver-libs',
+  'nvidia-driver-devel',
+  'nvidia-driver-NVML',
+  'nvidia-driver-NvFBCOpenGL',
+  'nvidia-driver-cuda',
+  'nvidia-driver-cuda-libs',
+
+  'nvidia-persistenced',
+  'nvidia-modprobe',
+  'nvidia-settings',
+  'nvidia-xconfig',
+
+  'cuda-drivers-redhat',
+]
+
+class Writer:
+    output = ''
+
+    def line(self, str):
+        self.output += str + '\n'
+
+    def write(self, target):
+        if len(target) == 0:
+            print(self.output)
+        else:
+            with open(target, 'w') as text_file:
+                print(self.output, file=text_file)
+
+    def tab(self):
+        self.output += '    '
+        return self
+
+    def next(self):
+        self.output += '...\n---\n'
+
+
+
+class Branch:
+    def __init__(self, name, major, minor):
+        self.name = name
+        self.major = major
+        self.minor = minor
+
+    def __repr__(self):
+        return 'Branch ' + self.name + '(' + self.major + '.' + self.minor + ')'
+
+    def __lt__(self, other):
+        if self.major != other.major:
+            return other.major < self.major;
+
+        return other.minor < self.minor;
+
+    def version(self):
+        return str(self.major) + '.' + str(self.minor)
+
+    def is_dkms(self):
+        return 'dkms' in self.name
+
+def kmod_belongs_to(kmod_filename, branch):
+    return branch.version() in kmod_filename
+
+def get_rpm_epoch(rpmfile, repodir):
+    cmd = ['rpm', '-q', '--qf', '%{epochnum}', repodir + rpmfile]
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    stdout = process.communicate()[0]
+
+    return stdout
+
+def rpm_is_pkgname(rpm, pkgname, pkgversion = ''):
+    """
+    checks whether the given rpm filename fits the given package name
+    """
+    rpm_stops = len(rpm.split('-'))
+    pkg_stops = len(pkgname.split('-'))
+
+    if pkgversion == '':
+        return rpm.startswith(pkgname) and rpm_stops == pkg_stops + 2
+    else:
+        return rpm.startswith(pkgname) and pkgversion in rpm and rpm_stops == pkg_stops + 2
+
+def rpm_from_pkgname(rpms, pkgname, pkgversion = ''):
+    relevant_rpms = filter(lambda f: rpm_is_pkgname(f, pkgname, pkgversion), rpms)
+
+    if len(relevant_rpms) == 0:
+        return None
+
+    # If no pkgversion is given, we prefer the one with the highest version number,
+    # just like package managers do.
+    if pkgversion == '':
+        relevant_rpms.sort(reverse = True) # Simply sort by name
+    else:
+        if len(relevant_rpms) > 1:
+            print('Expected exactly one rpm for branch package "' + pkgname + '" in version ' \
+                    + pkgversion + ' but I have ' + str(relevant_rpms))
+
+    return relevant_rpms[0]
+
+def filename_to_nevra(filename, repodir):
+    epoch = get_rpm_epoch(filename, repodir)
+    # Remove file extension
+    filename = filename[:filename.rfind('.')]
+    # Remove arch
+    arch = filename[filename.rfind('.') + 1:]
+    filename = filename[:filename.rfind('.')]
+    # Remove dist
+    dist = filename[filename.rfind('.') + 1:]
+    filename = filename[:filename.rfind('.')]
+    hyphen_parts = filename.split('-')
+    nevra = ''
+    for i in range(0, len(hyphen_parts) - 2):
+        nevra += hyphen_parts[i]
+        nevra += '-'
+
+    nevra += str(epoch)+ ':'
+    nevra += hyphen_parts[len(hyphen_parts) - 2]
+    nevra += '-' + hyphen_parts[len(hyphen_parts) - 1]
+    nevra += '.' + dist
+    nevra += '.' + arch
+
+    return nevra
+
+if __name__ == '__main__':
+    repodir = './rpms/'
+    outfile = ''
+
+    if len(sys.argv) > 1:
+        repodir = sys.argv[1]
+    else:
+        print('Usage: ' + sys.argv[0] + ' [INDIR] [OUTFILE]')
+        sys.exit()
+
+    if len(sys.argv) > 2:
+        outfile = sys.argv[2]
+
+    out = Writer()
+    now = datetime.datetime.now()
+
+    repodir_contents = listdir(repodir)
+    rpm_files = filter(lambda f: isfile(join(repodir, f)), repodir_contents)
+    driver_rpms = filter(lambda n: n.startswith(BRANCH_PKGS[0]), rpm_files)
+    kmod_rpms = filter(lambda n: n.startswith(KMOD_PKG_PREFIX), rpm_files)
+
+    branches = []
+    # Figure out the branches
+    driver_rpms.sort(reverse = True)
+    for pkg in driver_rpms:
+        stops = len(BRANCH_PKGS[0].split('-'))
+        pkg_stops = len(pkg.split('-'))
+        if (pkg_stops != stops + 2):
+            continue
+
+        n = pkg[len(BRANCH_PKGS[0]) + 1:]
+        version = n[0:n.index('-')]
+        version_parts = version.split('.')
+        major = version_parts[0]
+        minor = version_parts[1]
+
+        if len(branches) == 0:
+            branches.append(Branch(major, major, minor))
+        elif len(branches) > 0 and branches[len(branches) - 1].major != major:
+            branches.append(Branch(major, major, minor))
+
+    branches.sort()
+
+    # Add 'latest' branch with the same version as the highest-versioned other branch
+    latest = branches[0]
+    latest_branch = Branch('latest', latest.major, latest.minor)
+    branches.insert(0, latest_branch)
+    print('Latest Branch: ' + latest_branch.version())
+
+    for index, branch in enumerate(branches):
+        if 'dkms' in branch.name:
+            continue;
+
+        dkms_branch = Branch(branch.name + '-dkms', branch.major, branch.minor)
+        branches.insert(index + 1, dkms_branch)
+
+    for branch in branches:
+        print('Branch: ' + branch.name + '(Version: ' + branch.version()  + ')')
+        out.line('document: modulemd')
+        out.line('version: 2')
+        out.line('data:')
+        out.tab().line('name: nvidia-driver')
+        out.tab().line('stream: ' + branch.name)
+        out.tab().line('version: ' + now.strftime('%Y%m%d%H%M%S'))
+        out.tab().line('arch: x86_64')
+        out.tab().line('summary: Nvidia driver for ' + branch.name + ' branch')
+        out.tab().line('description: >-')
+        for line in DESCRIPTION:
+            out.tab().tab().line(line.replace('{version}', branch.version()))
+        out.tab().line('license:')
+        out.tab().tab().line('module:')
+        out.tab().tab().tab().line('- MIT')
+
+        out.tab().line('profiles:')
+        out.tab().tab().line('default:')
+        out.tab().tab().tab().line('description: Default installation')
+        out.tab().tab().tab().line('rpms:')
+        out.tab().tab().tab().tab().line('- ' + BRANCH_PKGS[0])
+        if branch.is_dkms():
+            out.tab().tab().tab().tab().line('- dkms-nvidia')
+
+
+        out.tab().line('artifacts:')
+        out.tab().tab().line('rpms:')
+        for pkg in BRANCH_PKGS:
+            branch_pkg = rpm_from_pkgname(rpm_files, pkg, branch.version())
+            if branch_pkg:
+                out.tab().tab().tab().line('- ' + filename_to_nevra(branch_pkg, repodir))
+            else:
+                print('WARNING: Branch ' + branch.name + ' does not have a ' + pkg + ' package')
+
+        for pkg in LATEST_PKGS:
+            latest_pkg = rpm_from_pkgname(rpm_files, pkg)
+            out.tab().tab().tab().line('- ' + filename_to_nevra(latest_pkg, repodir))
+
+        # All the kmod rpms which belong to this branch
+        for rpm in filter(lambda r: kmod_belongs_to(r, branch), kmod_rpms):
+            out.tab().tab().tab().line('- ' + filename_to_nevra(rpm, repodir))
+
+        if branch.is_dkms():
+            dkms_pkg = rpm_from_pkgname(rpm_files, 'dkms-nvidia', branch.version())
+            if dkms_pkg:
+                out.tab().tab().tab().line('- ' + filename_to_nevra(dkms_pkg, repodir))
+            else:
+                print('WARNING: Branch ' + branch.name + ' does not have a dkms-nvidia package')
+
+        out.next()
+
+    out.line('document: modulemd-defaults')
+    out.line('version: 1')
+    out.line('data:')
+    out.tab().line('module: nvidia-driver')
+    out.tab().line('stream: latest')
+    out.tab().line('profiles:')
+    for branch in branches:
+        out.tab().tab().line(branch.name + ': [default]')
+
+    out.write(outfile)
+
+    # Run modulemd-validator on the output, to catch
+    # bugs early. Since modifyrepo doesn't do it...
+    if len(outfile) > 0 and os.path.isfile('/usr/bin/modulemd-validator'):
+        process = subprocess.Popen(['/usr/bin/modulemd-validator', outfile], \
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout = process.communicate()[0]
+
+        if process.returncode != 0:
+            print(stdout)

--- a/genmodules.py
+++ b/genmodules.py
@@ -45,6 +45,7 @@ BRANCH_PKGS = [
   'nvidia-modprobe',
   'nvidia-settings',
   'nvidia-libXNVCtrl',
+  'nvidia-libXNVCtrl-devel',
   'nvidia-xconfig',
   'nvidia-kmod-common',
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -60,9 +60,9 @@ Source3:    %{hsm_wrapper_script}
 %endif
 
 
-Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
-Version:	%{kmod_driver_version}
-Release:	3%{kmod_dist}
+Name:		kmod-%{kmod_vendor}-%{_named_version}
+Version:	%{kmod_kernel}
+Release:	%{kmod_kernel_release}.r%{kmod_driver_version}%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -308,6 +308,11 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Tue Nov 16 2021 Alex Domingo <alex.domingo.toro@vub.be>
+ - Fix conflict resolution with kmod-nvidia-latest-dkms
+ - Disable module signing
+ - Roll back RPM navimg scheme to static names
+
 * Wed Jul 07 2021 Kevin Mittman <kmittman@nvidia.com>
  - Add two-pass HSM certificate signing flow
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -87,7 +87,7 @@ Provides:		nvidia-kmod = %{?epoch:%{epoch}:}%{kmod_driver_version}
 Requires(post):		/usr/bin/strip
 
 Conflicts:      kmod-nvidia-latest-dkms
-Provides:       kmod-nvidia-latest-dkms
+Provides:       kmod-nvidia-latest-dkms = %{kmod_driver_version}-1%{kmod_dist}
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmod_kernel_version})

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -202,7 +202,7 @@ for m in %{kmod_modules}; do
 	ko_size=`du -b "${m}.ko" | cut -f1`
 	tail ${m}.ko-signature -c +$(($ko_size + 1)) > ${m}.sig
 done
-
+%endif
 
 %post
 unset LD_RUN_PATH
@@ -282,7 +282,6 @@ install nvidia-drm.o %{buildroot}/%{kmod_o_dir}/nvidia-drm/
 
 # peermem
 install nvidia-peermem.mod.o %{buildroot}/%{kmod_o_dir}/
-install nvidia-peermem.sig %{buildroot}/%{kmod_o_dir}/
 install nvidia-peermem.o %{buildroot}/%{kmod_o_dir}/nvidia-peermem/
 
 # misc

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -80,14 +80,13 @@ Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmo
 # We cannot require the version of the driver in the kmod package since
 # dnf won't remove the kmod package automatically when enabling a different
 # module stream. This will cause the transaction to fail.
-#Requires:	nvidia-driver = %{epoch}:%{version}
+#Requires:	nvidia-driver = %%{epoch}:%%{version}
 
 # This works though and will automatically remove the kmod package when removing
 # the kernel package.
 Requires: (kernel = %{kmod_kernel_version} if kernel)
 Conflicts: kmod-nvidia-latest-dkms
-
-%endif # fedora/rhel8
+%endif
 
 %description
 The NVidia %{kmod_driver_version} display driver kernel module for kernel %{kmod_kernel_version}
@@ -285,7 +284,7 @@ rm -rf $RPM_BUILD_ROOT
 * Thu Apr 30 2020 Kevin Mittman <kmittman@nvidia.com>
  - Unique ld.gold filename
 
-* Wed Apr 28 2020 Timm Bäder <tbaeder@redhat.com>
+* Tue Apr 28 2020 Timm Bäder <tbaeder@redhat.com>
  - Removed unused kmod_rpm_release variable
  - Fix kernel_dist fallback to %%{dist}
  - Remove -m elf_x86_64 argument from linker invocations

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -264,31 +264,15 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 %files
 %defattr(644,root,root,755)
 
-# nvidia.o
-%{kmod_o_dir}/nvidia.mod.o
-%{kmod_o_dir}/nvidia.sig
-%{kmod_o_dir}/nvidia/nv-interface.o
-%{kmod_o_dir}/nvidia/nv-kernel.o
-
-# nvidia-uvm.o
-%{kmod_o_dir}/nvidia-uvm.mod.o
-%{kmod_o_dir}/nvidia-uvm.sig
-%{kmod_o_dir}/nvidia-uvm/nvidia-uvm.o
-
-# nvidia-modeset.o
-%{kmod_o_dir}/nvidia-modeset.mod.o
-%{kmod_o_dir}/nvidia-modeset.sig
-%{kmod_o_dir}/nvidia-modeset/nv-modeset-interface.o
-%{kmod_o_dir}/nvidia-modeset/nv-modeset-kernel.o
-
-# nvidia-drm.o
-%{kmod_o_dir}/nvidia-drm.mod.o
-%{kmod_o_dir}/nvidia-drm.sig
-%{kmod_o_dir}/nvidia-drm/nvidia-drm.o
-
+%{kmod_o_dir}
+%{kmod_share_dir}
 %{postld}
 
-%{kmod_share_dir}/module-common.lds
+%ghost %{kmod_module_path}
+%ghost %{kmod_module_path}/nvidia.ko
+%ghost %{kmod_module_path}/nvidia-uvm.ko
+%ghost %{kmod_module_path}/nvidia-drm.ko
+%ghost %{kmod_module_path}/nvidia-modeset.ko
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -211,10 +211,10 @@ for m in %{kmod_modules}; do
 	cat %{kmod_o_dir}/${m}.sig >> %{kmod_module_path}/${m}.ko
 done
 
-depmod -a
+depmod -a -w %{kmod_kernel_version}
 
 %postun
-depmod -a
+depmod -a -w %{kmod_kernel_version}
 
 
 %install
@@ -277,6 +277,9 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Fri Oct 09 2020 Kevin Mittman <kmittman@nvidia.com>
+ - Run depmod for target kernel version, not running kernel
+
 * Thu May 07 2020 Timm Bäder <tbaeder@redhat.com>
  - List generated files as %%ghost files
  - Only require the kernel if any kernel is installed

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -126,8 +126,8 @@ rm nvidia-modeset.o
 
 # Link our own nvidia.o and nvidia-modeset.o from the -interface.o and the -kernel.o.
 # This is necessary because we just stripped the input .o files
-%{_ld} -r -m elf_x86_64 -o nvidia.o nvidia/nv-interface.o nvidia/nv-kernel.o
-%{_ld} -r -m elf_x86_64 -o nvidia-modeset.o nvidia-modeset/nv-modeset-interface.o nvidia-modeset/nv-modeset-kernel.o
+%{_ld} -r -o nvidia.o nvidia/nv-interface.o nvidia/nv-kernel.o
+%{_ld} -r -o nvidia-modeset.o nvidia-modeset/nv-modeset-interface.o nvidia-modeset/nv-modeset-kernel.o
 
 
 # The build above has already linked a module.ko, but we do it again here
@@ -138,7 +138,7 @@ for m in %{kmod_modules}; do
 	%{strip} ${m}.o --keep-symbol=init_module --keep-symbol=cleanup_module
 	rm ${m}.ko
 
-	%{_ld} -r -m elf_x86_64 \
+	%{_ld} -r \
 		-z max-page-size=0x200000 -T %{kmod_kernel_source}/scripts/module-common.lds \
 		--build-id -r \
 		-o ${m}.ko \
@@ -179,31 +179,29 @@ mkdir -p %{kmod_module_path}
 chmod +x %{postld}
 
 # link nvidia.o
-%{postld} -m elf_x86_64 \
-	-z max-page-size=0x200000 -r \
+%{postld} -z max-page-size=0x200000 -r \
 	-o nvidia.o \
 	nvidia/nv-interface.o \
 	nvidia/nv-kernel.o
 
 %{strip} nvidia.o
-%{postld} -r -m elf_x86_64 -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia.ko nvidia.o nvidia.mod.o
+%{postld} -r -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia.ko nvidia.o nvidia.mod.o
 rm nvidia.o
 
-%{postld} -r -m elf_x86_64 -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-uvm.ko nvidia-uvm/nvidia-uvm.o nvidia-uvm.mod.o
+%{postld} -r -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-uvm.ko nvidia-uvm/nvidia-uvm.o nvidia-uvm.mod.o
 
 # nvidia-modeset.o
-%{postld} -m elf_x86_64 \
-	-z max-page-size=0x200000 -r \
+%{postld} -z max-page-size=0x200000 -r \
 	-o nvidia-modeset.o \
 	nvidia-modeset/nv-modeset-interface.o \
 	nvidia-modeset/nv-modeset-kernel.o
 
 %{strip} nvidia-modeset.o
-%{postld} -r -m elf_x86_64 -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-modeset.ko nvidia-modeset.o nvidia-modeset.mod.o
+%{postld} -r -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-modeset.ko nvidia-modeset.o nvidia-modeset.mod.o
 rm nvidia-modeset.o
 
 
-%{postld} -r -m elf_x86_64 -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-drm.ko nvidia-drm/nvidia-drm.o nvidia-drm.mod.o
+%{postld} -r -T %{kmod_share_dir}/module-common.lds --build-id -o %{kmod_module_path}/nvidia-drm.ko nvidia-drm/nvidia-drm.o nvidia-drm.mod.o
 
 
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -85,7 +85,7 @@ Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmo
 # This works though and will automatically remove the kmod package when removing
 # the kernel package.
 Requires: kernel = %{kmod_kernel_version}
-Conflicts: dkms-nvidia
+Conflicts: kmod-nvidia-latest-dkms
 
 %endif # fedora/rhel8
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -51,7 +51,7 @@ Source2:	public_key.der
 
 Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
 Version:	%{kmod_driver_version}
-Release:	2%{kmod_dist}
+Release:	3%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia
@@ -295,6 +295,13 @@ install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_vers
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Wed Apr 28 2020 Timm Bäder <tbaeder@redhat.com>
+ - Removed unused kmod_rpm_release variable
+ - Fix kernel_dist fallback to %%{dist}
+ - Remove -m elf_x86_64 argument from linker invocations
+ - Add /usr/bin/strip requirement for %%post scriptlet
+ - Conflict with kmod-nvidia-latest-dkms, not dkms-nvidia
+
 * Fri Dec 06 2019 Kevin Mittman <kmittman@nvidia.com>
  - Pass %{kernel_dist} as it may not match the system %{dist}
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -9,6 +9,9 @@
 # Named version, usually just the driver version, or "latest"
 %define _named_version %{driver_branch}
 
+# Distribution name, like .el8 or .el8_1
+%define kmod_dist %{kernel_dist}%{?!kernel_dist:.el8}
+
 %define kmod_vendor		nvidia
 %define kmod_driver_version	%{driver}
 %define kmod_rpm_release	1
@@ -16,7 +19,7 @@
 # there's no --define="kernel x.y.z" passed to rpmbuild
 %define kmod_kernel		%{?kernel}%{?!kernel:3.10.0}
 %define kmod_kernel_release	%{?kernel_release}%{?!kernel_release:862}
-%define kmod_kernel_version	%{kmod_kernel}-%{kmod_kernel_release}%{dist}
+%define kmod_kernel_version	%{kmod_kernel}-%{kmod_kernel_release}%{kmod_dist}
 %define kmod_kbuild_dir		drivers/video/nvidia
 %define kmod_module_path	/lib/modules/%{kmod_kernel_version}.%{_arch}/extra/%{kmod_kbuild_dir}
 %define kmod_share_dir		%{_prefix}/share/nvidia-%{kmod_kernel_version}
@@ -49,7 +52,7 @@ Source2:	public_key.der
 
 Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
 Version:	%{kmod_driver_version}
-Release:	2%{dist}
+Release:	2%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia
@@ -294,6 +297,9 @@ install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_vers
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Fri Dec 06 2019 Kevin Mittman <kmittman@nvidia.com>
+ - Pass %{kernel_dist} as it may not match the system %{dist}
+
 * Fri Jun 07 2019 Kevin Mittman <kmittman@nvidia.com>
  - Rename package, Change Requires, Remove %ghost
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -10,7 +10,7 @@
 %define _named_version %{driver_branch}
 
 # Distribution name, like .el8 or .el8_1
-%define kmod_dist %{kernel_dist}%{?!kernel_dist:.el8}
+%define kmod_dist %{?kernel_dist}%{?!kernel_dist:%{dist}}
 
 %define kmod_vendor		nvidia
 %define kmod_driver_version	%{driver}

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -73,6 +73,7 @@ Provides:		kernel-modules = %kmod_kernel_version.%{_target_cpu}
 # DKMS kernel module package both provide this and the driver package only needs
 # one of them to satisfy the dependency.
 Provides:		nvidia-kmod = %{?epoch:%{epoch}:}%{kmod_driver_version}
+Requires(post):		/usr/bin/strip
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmod_kernel_version})

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -14,7 +14,6 @@
 
 %define kmod_vendor		nvidia
 %define kmod_driver_version	%{driver}
-%define kmod_rpm_release	1
 # We use some default kernel (here the current RHEL 7.5 one) if
 # there's no --define="kernel x.y.z" passed to rpmbuild
 %define kmod_kernel		%{?kernel}%{?!kernel:3.10.0}

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -28,7 +28,7 @@
 %define kmod_modules		nvidia nvidia-uvm nvidia-modeset nvidia-drm
 # For compatibility with upstream Negativo17 shell scripts, we use nvidia-kmod
 # instead of kmod-nvidia for the source tarball.
-%define kmod_source_name	%{kmod_vendor}-kmod-%{kmod_driver_version}-x86_64
+%define kmod_source_name	%{kmod_vendor}-kmod-%{kmod_driver_version}-%{_arch}
 %define kmod_kernel_source	/usr/src/kernels/%{kmod_kernel_version}.%{_arch}
 
 # Global re-define for the strip command we apply to all the .o files
@@ -63,7 +63,7 @@ BuildRequires:	redhat-rpm-config
 BuildRequires:	elfutils-libelf-devel
 BuildRequires:	%{_ld}
 BuildRequires:	openssl
-ExclusiveArch:	x86_64
+ExclusiveArch:	x86_64 ppc64le aarch64
 
 %if 0%{?rhel} == 7
 	%global _use_internal_dependency_generator 0
@@ -277,6 +277,9 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Tue Apr 27 2021 Kevin Mittman <kmittman@nvidia.com>
+ - Unofficial support for ppc64le and aarch64
+
 * Wed Oct 21 2020 Kevin Mittman <kmittman@nvidia.com>
  - Include architecture in depmod command
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -84,7 +84,7 @@ Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmo
 
 # This works though and will automatically remove the kmod package when removing
 # the kernel package.
-Requires: kernel = %{kmod_kernel_version}
+Requires: (kernel = %{kmod_kernel_version} if kernel)
 Conflicts: kmod-nvidia-latest-dkms
 
 %endif # fedora/rhel8

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -39,7 +39,7 @@
 %define _ld %{_bindir}/ld.gold
 # postld is the ld version we ship ourselves, install and then use
 # in %post to link the final kernel module
-%define postld %{_bindir}/ld.gold.nvidia.%{kmod_driver_version}
+%define postld %{_bindir}/ld.gold.nvidia.%{kmod_driver_version}.%{kmod_kernel_version}
 
 %define debug_package %{nil}
 %define sbindir %( if [ -d "/sbin" -a \! -h "/sbin" ]; then echo "/sbin"; else echo %{_sbindir}; fi )
@@ -258,8 +258,7 @@ install nvidia-drm.o %{buildroot}/%{kmod_o_dir}/nvidia-drm/
 # misc
 install -m 644 -D module-common.lds %{buildroot}/%{kmod_share_dir}/
 
-install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_version}
-
+install -m 755 ld.gold %{buildroot}/%{postld}
 
 
 %files
@@ -287,7 +286,7 @@ install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_vers
 %{kmod_o_dir}/nvidia-drm.sig
 %{kmod_o_dir}/nvidia-drm/nvidia-drm.o
 
-%{_bindir}/ld.gold.nvidia.%{kmod_driver_version}
+%{postld}
 
 %{kmod_share_dir}/module-common.lds
 
@@ -295,6 +294,9 @@ install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_vers
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Thu Apr 30 2020 Kevin Mittman <kmittman@nvidia.com>
+ - Unique ld.gold filename
+
 * Wed Apr 28 2020 Timm Bäder <tbaeder@redhat.com>
  - Removed unused kmod_rpm_release variable
  - Fix kernel_dist fallback to %%{dist}

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -51,7 +51,7 @@ Source2:	public_key.der
 
 Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
 Version:	%{kmod_driver_version}
-Release:	4%{kmod_dist}
+Release:	2%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -211,10 +211,10 @@ for m in %{kmod_modules}; do
 	cat %{kmod_o_dir}/${m}.sig >> %{kmod_module_path}/${m}.ko
 done
 
-depmod -a -w %{kmod_kernel_version}
+depmod -a -w %{kmod_kernel_version}.%{_arch}
 
 %postun
-depmod -a -w %{kmod_kernel_version}
+depmod -a -w %{kmod_kernel_version}.%{_arch}
 
 
 %install
@@ -277,6 +277,9 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Wed Oct 21 2020 Kevin Mittman <kmittman@nvidia.com>
+ - Include architecture in depmod command
+
 * Fri Oct 09 2020 Kevin Mittman <kmittman@nvidia.com>
  - Run depmod for target kernel version, not running kernel
 

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -51,7 +51,7 @@ Source2:	public_key.der
 
 Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
 Version:	%{kmod_driver_version}
-Release:	3%{kmod_dist}
+Release:	4%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia
@@ -278,6 +278,10 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Thu May 07 2020 Timm Bäder <tbaeder@redhat.com>
+ - List generated files as %%ghost files
+ - Only require the kernel if any kernel is installed
+
 * Thu Apr 30 2020 Kevin Mittman <kmittman@nvidia.com>
  - Unique ld.gold filename
 


### PR DESCRIPTION
This PR looks messy because I'm syncing our branch with the [470](https://github.com/NVIDIA/yum-packaging-precompiled-kmod/tree/470) branch upstream. But the changes are rather minor:

* https://github.com/vub-hpc/yum-packaging-precompiled-kmod/commit/f6c27c5d6bb2c779d85eb6ac3862905b4e6f9bab Synch with 470
* https://github.com/vub-hpc/yum-packaging-precompiled-kmod/commit/9a78e0f19bef2d6edc51b9c1174e467a9f3a45c6 Having the same `Conflicts` and `Provides` makes it impossible to upgrade because the new version will conflict with its older version as it provides the conflicted package. Solution is to set a specific version in `Provides`.
* https://github.com/vub-hpc/yum-packaging-precompiled-kmod/commit/32d7f5d294d2085fa29a891a4609e67c987780f7 keep all module signing disabled as we are already doing
* https://github.com/vub-hpc/yum-packaging-precompiled-kmod/commit/209ea4c86cbe03bec36eaee8a12ea2369a37b320 roll back the naming scheme to our usual format